### PR TITLE
fixed sound(door lock) sound

### DIFF
--- a/src/scripts/DoorsReach.mjs
+++ b/src/scripts/DoorsReach.mjs
@@ -306,7 +306,7 @@ export const DoorsReach = {
     let playpath = "";
     let playVolume = 0.8;
 
-    if (object.ds === CONST.WALL_DOOR_STATES.LOCKED) {
+    if (updateData.ds === CONST.WALL_DOOR_STATES.LOCKED) {
       // Door Unlocking
       playpath = doorData.unlockPath;
       playVolume = doorData.unlockLevel;


### PR DESCRIPTION
The sound played for every door update. The code checked door state, not update state at the begining.