### PR TITLE
Fixed bug in reselectTokenAfterInteraction function

### DIFF
--- a/src/scripts/ArmsReachHelper.mjs
+++ b/src/scripts/ArmsReachHelper.mjs
@@ -360,7 +360,7 @@ export const reselectTokenAfterInteraction = function (character) {
         // DO NOTHING
       } else {
         const observable = canvas.tokens?.placeables.filter((t) => t.id === character.id);
-        if (observable !== undefined) {
+        if (observable.length) {
           observable[0].control();
         }
       }


### PR DESCRIPTION
There was a chance that this function ends with an error assuming that character is not present in the current scene.