### PR TITLE
Fix for tile selection

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -749,7 +749,7 @@ export const DrawingPrototypeOnClickLeftHandler = async function (wrapped, ...ar
   return wrapped(...args);
 };
 
-export const TilePrototypeOnClickLeftHandler = async function (wrapped, ...args) {
+export const TilePrototypeOnClickLeftHandler = function (wrapped, ...args) {
   if (game.settings.get(CONSTANTS.MODULE_ID, "enableTilesIntegration")) {
     const [target] = args;
     const tile = this;
@@ -776,7 +776,7 @@ export const TilePrototypeOnClickLeftHandler = async function (wrapped, ...args)
       }
       return wrapped(...args);
     }
-    const isInReach = await TilesReach.globalInteractionDistance(tokenSelected, tile);
+    const isInReach = TilesReach.globalInteractionDistance(tokenSelected, tile);
     if (!doNotReselectIfGM) {
       reselectTokenAfterInteraction(tokenSelected);
     }


### PR DESCRIPTION
This should be an easy fix for the tile selection bug as mentioned in #102 and #94 

I think the async in the wrapper function was messing with the `.stoppropagation`, causing the left click to reach the tiles layer itseld