### PR TITLE
Compatibility fix for Stairways

### DIFF
--- a/src/scripts/StairwaysReach.js
+++ b/src/scripts/StairwaysReach.js
@@ -45,7 +45,10 @@ export const StairwaysReach = {
                 : game.settings.get(CONSTANTS.MODULE_ID, "stairwayInteractionMeasurement");
         let range =
             //foundry.utils.getProperty(targetPlaceableObject, `flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.RANGE}`) || 0;
-			targetPlaceableObject.document.getFlag(CONSTANTS.MODULE_ID, CONSTANTS.FLAGS.RANGE) || 0;
+            targetPlaceableObject?.document?.getFlag(CONSTANTS.MODULE_ID, CONSTANTS.FLAGS.RANGE) || // Placeable object with .document
+            targetPlaceableObject?.getFlag?.(CONSTANTS.MODULE_ID, CONSTANTS.FLAGS.RANGE) || // Document instance with .getFlag()
+            targetPlaceableObject?.flags?.[CONSTANTS.MODULE_ID]?.[CONSTANTS.FLAGS.RANGE] || // Raw data object from hooks
+            0;
         globalInteraction = range > 0 ? range : globalInteraction;
         // Global interaction distance control. Replaces prototype function of Stairways. Danger...
         // if (globalInteraction > 0) {


### PR DESCRIPTION
Had errors in console and no functionality between the two modules, decided to look into it!
v13 of foundry, 0.11.1 of Stairways.

Stairways is sending its data raw and not in a placeable object .document, this caused the error as Arms Reach was only looking for a .document. Sending raw data over API is the preferred way of doing this, so its on "us" to handle the data.

Fix was to check first for .document for any possible backwards compatibility I might not be aware of, then check for raw data objects. Now the console errors are gone and module compatibility is restored!

This fix could probably be made into a helper function as the same document getflag code is repeated often, this might help with module compatibility.

Hope this helps!