### PR TITLE
Fix ApplicationV2 config sheet injection (v13+) + bump Foundry v14 compat

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -9,18 +9,18 @@ import { ArmsReachFormConfig } from "./scripts/lib/ArmsReachFormConfig.js";
 /* Initialize module					*/
 /* ------------------------------------ */
 Hooks.once("init", async () => {
-    Logger.log(`${CONSTANTS.MODULE_ID} | Initializing ${CONSTANTS.MODULE_ID}`);
+  Logger.log(`${CONSTANTS.MODULE_ID} | Initializing ${CONSTANTS.MODULE_ID}`);
 
-    // Register custom module settings
-    registerSettings();
-    registerKeyBindings();
+  // Register custom module settings
+  registerSettings();
+  registerKeyBindings();
 
-    // Assign custom classes and constants here
-    initHooks();
+  // Assign custom classes and constants here
+  initHooks();
 
-    // Preload Handlebars templates
-    await preloadTemplates();
-    // Register custom sheets (if any)
+  // Preload Handlebars templates
+  await preloadTemplates();
+  // Register custom sheets (if any)
 });
 
 /* ------------------------------------ */
@@ -28,36 +28,43 @@ Hooks.once("init", async () => {
 /* ------------------------------------ */
 
 Hooks.once("setup", function () {
-    // Do anything after initialization but before ready
-    // setupModules();
+  // Do anything after initialization but before ready
+  // setupModules();
 
-    // registerSettings();
+  // registerSettings();
 
-    setupHooks();
+  setupHooks();
 });
 
 /* ------------------------------------ */
 /* When ready							*/
 /* ------------------------------------ */
 Hooks.once("ready", () => {
-    // Do anything once the module is ready
-    if (!game.modules.get("lib-wrapper")?.active && game.user?.isGM) {
-        Logger.error(
-            `The '${CONSTANTS.MODULE_ID}' module requires to install and activate the 'libWrapper' module.`,
-            true,
-        );
-        return;
-    }
-    if (game.modules.get("foundryvtt-arms-reach")?.active && game.user?.isGM) {
-        Logger.error(
-            `Attention in version 11 the module id of "foundryvtt-arms-reach" has become "arms-reach". If present uninstall the "foundryvtt-arms-reach" version.`,
-            true,
-        );
-    }
-    readyHooks();
+  // Do anything once the module is ready
+  if (!game.modules.get("lib-wrapper")?.active && game.user?.isGM) {
+    Logger.error(`The '${CONSTANTS.MODULE_ID}' module requires to install and activate the 'libWrapper' module.`, true);
+    return;
+  }
+  if (game.modules.get("foundryvtt-arms-reach")?.active && game.user?.isGM) {
+    Logger.error(
+      `Attention in version 11 the module id of "foundryvtt-arms-reach" has become "arms-reach". If present uninstall the "foundryvtt-arms-reach" version.`,
+      true,
+    );
+  }
+  readyHooks();
 });
 
-// Add any additional hooks if necessary
+// Add any additional hooks if necessary.
+//
+// Foundry v13 converted TokenConfig, TileConfig, AmbientLightConfig, AmbientSoundConfig,
+// WallConfig, NoteConfig, DrawingConfig, MeasuredTemplateConfig (removed in v14), LightConfig
+// and StairwayConfig to ApplicationV2. The legacy `renderFormApplication` hook no longer
+// fires for those, which is why the "Arms Reach Range" fieldset stopped appearing in v13+.
+// Hook on `renderApplicationV2` as well, and keep the V1 hook so anything that stayed V1
+// (or third-party V1 configs from other modules) still gets the injection.
 Hooks.on("renderFormApplication", (app, html, options) => {
-    ArmsReachFormConfig._handleRenderFormApplication(app, html);
+  ArmsReachFormConfig._handleRenderFormApplication(app, html);
+});
+Hooks.on("renderApplicationV2", (app, html, data) => {
+  ArmsReachFormConfig._handleRenderFormApplication(app, html);
 });

--- a/src/module.json
+++ b/src/module.json
@@ -72,8 +72,8 @@
     "styles": ["styles/arms-reach.css"],
     "compatibility": {
         "minimum": 13,
-        "verified": 13,
-        "maximum": 13
+        "verified": 14,
+        "maximum": 14
     },
     "url": "https://github.com/p4535992/foundryvtt-arms-reach",
     "manifest": "https://github.com/p4535992/foundryvtt-arms-reach/releases/download/13.0.4/module.json",

--- a/src/scripts/lib/ArmsReachFormConfig.js
+++ b/src/scripts/lib/ArmsReachFormConfig.js
@@ -2,104 +2,106 @@ import CONSTANTS from "../constants";
 import Logger from "./Logger";
 
 export class ArmsReachFormConfig {
-    static configHandlers = {
-        TokenConfig: "_handleTokenConfig",
-        TileConfig: "_handleTileConfig",
-        DrawingConfig: "_handleDrawingConfig",
-        AmbientLightConfig: "_handleAmbientLightConfig", // v9
-        LightConfig: "_handleGenericConfig", // v8
-        WallConfig: "_handleGenericConfig",
-        AmbientSoundConfig: "_handleGenericConfig",
-        MeasuredTemplateConfig: "_handleGenericConfig",
-        NoteConfig: "_handleGenericConfig",
-        StairwayConfig: "_handleStairwayConfig",
-    };
+  static configHandlers = {
+    TokenConfig: "_handleTokenConfig",
+    TileConfig: "_handleTileConfig",
+    DrawingConfig: "_handleDrawingConfig",
+    AmbientLightConfig: "_handleAmbientLightConfig", // v9
+    LightConfig: "_handleGenericConfig", // v8
+    WallConfig: "_handleGenericConfig",
+    AmbientSoundConfig: "_handleGenericConfig",
+    MeasuredTemplateConfig: "_handleGenericConfig",
+    NoteConfig: "_handleGenericConfig",
+    StairwayConfig: "_handleStairwayConfig",
+  };
 
-    static _handleRenderFormApplication(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        let method = ArmsReachFormConfig.configHandlers[app.constructor.name];
-        if (!method) {
-            const key = Object.keys(ArmsReachFormConfig.configHandlers).find((name) =>
-                app.constructor.name.includes(name),
-            );
-            if (!key) return;
-            method = ArmsReachFormConfig.configHandlers[key];
-        }
-        ArmsReachFormConfig[method](app, html, true);
+  static _handleRenderFormApplication(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
-
-    static _handleTokenConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        const elem = html.find(`div[data-tab="character"]`);
-        this._applyHtml(app, elem);
+    let method = ArmsReachFormConfig.configHandlers[app.constructor.name];
+    if (!method) {
+      const key = Object.keys(ArmsReachFormConfig.configHandlers).find((name) => app.constructor.name.includes(name));
+      if (!key) return;
+      method = ArmsReachFormConfig.configHandlers[key];
     }
+    // Foundry v13+ ApplicationV2 render hooks pass an HTMLElement instead of a jQuery object,
+    // but the individual handlers below use `html.find(...)` everywhere. Wrap once at entry
+    // so the rest of the file keeps its jQuery assumption.
+    const $html = typeof html?.find === "function" ? html : $(html);
+    ArmsReachFormConfig[method](app, $html, true);
+  }
 
-    static _handleTileConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        const elem = html.find(`div[data-tab="basic"]`);
-        this._applyHtml(app, elem);
+  static _handleTokenConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
+    const elem = html.find(`div[data-tab="character"]`);
+    this._applyHtml(app, elem);
+  }
 
-    static _handleDrawingConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        const elem = html.find(`div[data-tab="position"]`);
-        this._applyHtml(app, elem);
+  static _handleTileConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
+    const elem = html.find(`div[data-tab="basic"]`);
+    this._applyHtml(app, elem);
+  }
 
-    static _handleAmbientLightConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        let button = html.find(`button[name="submit"]`);
-        let elem = (button.length ? button : html.find(`button[type="submit"]`)).parent();
-        this._applyHtml(app, elem, true);
+  static _handleDrawingConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
+    const elem = html.find(`div[data-tab="position"]`);
+    this._applyHtml(app, elem);
+  }
 
-    static _handleGenericConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        let button = html.find(`button[name="submit"]`);
-        let elem = button.length ? button : html.find(`button[type="submit"]`);
-        this._applyHtml(app, elem, true);
+  static _handleAmbientLightConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
+    let button = html.find(`button[name="submit"]`);
+    let elem = (button.length ? button : html.find(`button[type="submit"]`)).parent();
+    this._applyHtml(app, elem, true);
+  }
 
-    static _handleStairwayConfig(app, html) {
-        if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
-            Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
-            return;
-        }
-        const elem = html.find(`div[data-tab="main"]`).find(".form-group").last();
-        this._applyHtml(app, elem);
+  static _handleGenericConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
     }
+    let button = html.find(`button[name="submit"]`);
+    let elem = button.length ? button : html.find(`button[type="submit"]`);
+    this._applyHtml(app, elem, true);
+  }
 
-    static _applyHtml(app, elem, insertBefore = false) {
-        if (!elem) {
-            return;
-        }
-        const object = app?.object?._object ?? app?.object;
-        const tagDocument = object?.document ?? object;
+  static _handleStairwayConfig(app, html) {
+    if (!game.settings.get(CONSTANTS.MODULE_ID, "enableAdditionalReachSettingOnPlaceableConfigSheet")) {
+      Logger.debug("Setting 'enableAdditionalReachSettingOnPlaceableConfigSheet' is disabled");
+      return;
+    }
+    const elem = html.find(`div[data-tab="main"]`).find(".form-group").last();
+    this._applyHtml(app, elem);
+  }
 
-        let range =
-            //foundry.utils.getProperty(tagDocument, `flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.RANGE}`) || 0;
-			tagDocument.getFlag(CONSTANTS.MODULE_ID, CONSTANTS.FLAGS.RANGE) || 0; //not strictly necessary here but for the sake uniformity
-        // let isEnabled = foundry.utils.getProperty(tagDocument, `flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}`) || false;
+  static _applyHtml(app, elem, insertBefore = false) {
+    if (!elem) {
+      return;
+    }
+    const object = app?.object?._object ?? app?.object;
+    const tagDocument = object?.document ?? object;
 
-        let fieldset = `
+    let range =
+      //foundry.utils.getProperty(tagDocument, `flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.RANGE}`) || 0;
+      tagDocument.getFlag(CONSTANTS.MODULE_ID, CONSTANTS.FLAGS.RANGE) || 0; //not strictly necessary here but for the sake uniformity
+    // let isEnabled = foundry.utils.getProperty(tagDocument, `flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}`) || false;
+
+    let fieldset = `
         <fieldset>
             <legend>Arms reach</legend>
             <div class="form-group">
@@ -114,19 +116,19 @@ export class ArmsReachFormConfig {
         </fieldset>
         `;
 
-        // <div class="form-group">
-        //         <label for="flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}">
-        //             Arms Reach Enabled ?
-        //         </label>
-        //         <div class="form-fields">
-        //             <input name="flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}" type="checkbox" ${isEnabled ? "checked" : ""} data-dtype="Boolean">
-        //         </div>
-        // </div>
+    // <div class="form-group">
+    //         <label for="flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}">
+    //             Arms Reach Enabled ?
+    //         </label>
+    //         <div class="form-fields">
+    //             <input name="flags.${CONSTANTS.MODULE_ID}.${CONSTANTS.FLAGS.ENABLED}" type="checkbox" ${isEnabled ? "checked" : ""} data-dtype="Boolean">
+    //         </div>
+    // </div>
 
-        if (insertBefore) {
-            $(fieldset).insertBefore(elem);
-        } else {
-            elem.append(fieldset);
-        }
+    if (insertBefore) {
+      $(fieldset).insertBefore(elem);
+    } else {
+      elem.append(fieldset);
     }
+  }
 }


### PR DESCRIPTION
## Summary
Addresses part of #104 ("does not work in v13") and adds Foundry v14 compatibility.

## Root cause
In v13, TokenConfig, TileConfig, AmbientLightConfig, AmbientSoundConfig, WallConfig, NoteConfig, DrawingConfig, LightConfig, and StairwayConfig were all converted to ApplicationV2. The legacy `renderFormApplication` hook no longer fires for ApplicationV2 apps, so the "Arms Reach Range" fieldset silently stopped being injected into any of those sheets — the per-placeable range override became unreachable in the UI.

## Changes
- **`src/module.js`** — also subscribe to `renderApplicationV2`. The V1 hook stays so any third-party or legacy V1 config form keeps getting the injection.
- **`src/scripts/lib/ArmsReachFormConfig.js`** — ApplicationV2 render hooks pass an `HTMLElement` instead of a jQuery object, but every handler below uses `html.find(...)`. Normalize once at the dispatch entry with `(html.find ? html : $(html))` so the rest of the file keeps its jQuery assumption unchanged.
- **`src/module.json`** — bump `compatibility.verified`/`maximum` to `14` (minimum unchanged at 13).

## Scope / what's NOT in this PR
This does not address the door-opening complaint in #104 if it persists after the Range field is reachable again. I don't have a reproducible console trace for that, and none was attached to the issue. If it turns out to be a separate bug (e.g. DoorControl prototype hook target changed in v13+), it should be tracked separately.

Also, the v14 breaking-change list (MeasuredTemplate removal, ActiveEffect schema, DataModel operators) doesn't appear to touch anything this module uses — it doesn't manipulate effects, templates, or call `-=`/`==` updates. I haven't done an exhaustive v14 functional pass, so this is verified/maximum `14` on the basis of "module loads and config-sheet injection works"; more serious issues may turn up in real play.

## Pre-commit hook note
lint-staged ran prettier against the two modified files. `main` currently does not pass its own `.prettierrc.json` (tabWidth 2 for `.js` in the config vs. 4-space indented source), so the hook reformatted the full files on commit. The functional change is the three localized edits described above; the rest is pure whitespace. Happy to split or revert the reformat if you prefer — just let me know.

## Test plan
- [x] Loads on Foundry v14.359 + dnd5e 5.3.0
- [x] Loads on Foundry v13 (minimum unchanged)
- [x] "Arms Reach Range" fieldset now appears in Token/Tile/Light/Wall/Note/Drawing config sheets on v13+
- [ ] Exhaustive functional pass across every reach integration — not done